### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "*"
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ErikaRS/task-list-kanban/security/code-scanning/1](https://github.com/ErikaRS/task-list-kanban/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or the specific job that requires it. Since the job creates a release, it needs `contents: write` permission (to create releases and upload assets). The minimal permissions required for this workflow are `contents: write`. You should add the following block at the top level of the workflow (before `jobs:`) to apply to all jobs, or inside the `build` job if you want to scope it more narrowly. The best practice is to add it at the workflow level unless you have multiple jobs with different needs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
