### PR TITLE
Make the author value in manifest.json consistent with community list

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
 	"version": "1.2.9",
 	"minAppVersion": "1.5.3",
 	"description": "Organizes all of the tasks within your files into a kanban view. Reduce duplication of effort when managing and prioritising tasks by simply using the task format in your files to automatically appear in your Task List Kanban.",
-	"author": "Erika Rice Scherpelz",
+	"author": "Chris Kerr, Erika Rice Scherpelz",
 	"authorUrl": "https://github.com/erikars",
 	"isDesktopOnly": false
 }


### PR DESCRIPTION
As well as retaining credit for the original author, it makes this plugin's manifest.json consistent with the value in the community catalogue, which is always helpful.

So I copied the author field from this PR:

https://github.com/obsidianmd/obsidian-releases/pull/7415/files