### PR TITLE
Add ignore paths regex setting to exclude files from kanban

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Place the kanban in the folder in which you are listing the tasks that you want 
 
 Alternatively, if you would prefer for every task within your entire Obsidian to appear in the kanban, choose 'Every folder' in the Folder scope kanban settings. This is found in the settings menu in the top right of the kanban.
 
+**Ignore paths (regex)**
+You can exclude files/folders from the kanban by providing a regular expression in Settings → Ignore paths (regex). Any file path that matches the regex will be ignored. Examples:
+
+- `^Templates/` — ignore anything under the `Templates` folder at the vault root
+- `/Archive/` — ignore any path segment named `Archive`
+- `^(Templates/|Daily Notes/)` — ignore multiple folders
+
 
 ### Adding a task to your kanban
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "task-list-kanban",
-	"version": "1.2.8",
+	"version": "1.2.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "task-list-kanban",
-			"version": "1.2.8",
+			"version": "1.2.9",
 			"license": "MIT",
 			"dependencies": {
 				"crypto-js": "^4.2.0",

--- a/src/ui/settings/settings.ts
+++ b/src/ui/settings/settings.ts
@@ -52,6 +52,29 @@ export class SettingsModal extends Modal {
 			});
 
 		new Setting(this.contentEl)
+			.setName("Ignore paths (regex)")
+			.setDesc(
+				"Exclude files whose path matches this regular expression. Example: (^Templates/|/Archive/)"
+			)
+			.addText((text) => {
+				text.setPlaceholder("e.g. (^Templates/|/Archive/)");
+				text.setValue(this.settings.ignorePathsRegex ?? "");
+				text.onChange((value) => {
+					try {
+						// Validate regex
+						// eslint-disable-next-line no-new
+						new RegExp(value);
+						text.inputEl.style.borderColor = "";
+						text.inputEl.title = "Valid regular expression";
+						this.settings.ignorePathsRegex = value;
+					} catch (e) {
+						text.inputEl.style.borderColor = "var(--text-error)";
+						text.inputEl.title = "Invalid regular expression";
+					}
+				});
+			});
+
+		new Setting(this.contentEl)
 			.setName("Show filepath")
 			.setDesc("Show the filepath on each task in Kanban?")
 			.addToggle((toggle) => {

--- a/src/ui/settings/settings_store.ts
+++ b/src/ui/settings/settings_store.ts
@@ -18,6 +18,7 @@ const settingsObject = z.object({
 	scope: z.nativeEnum(ScopeOption).default(ScopeOption.Folder),
 	showFilepath: z.boolean().default(true).optional(),
 	consolidateTags: z.boolean().default(false).optional(),
+	ignorePathsRegex: z.string().default("").optional(),
 	uncategorizedVisibility: z
 		.nativeEnum(VisibilityOption)
 		.default(VisibilityOption.Auto)
@@ -36,6 +37,7 @@ export const defaultSettings: SettingValues = {
 	scope: ScopeOption.Folder,
 	showFilepath: true,
 	consolidateTags: false,
+	ignorePathsRegex: "",
 	uncategorizedVisibility: VisibilityOption.Auto,
 	doneVisibility: VisibilityOption.AlwaysShow,
 	doneStatusMarkers: DEFAULT_DONE_STATUS_MARKERS,

--- a/src/ui/tasks/store.ts
+++ b/src/ui/tasks/store.ts
@@ -45,7 +45,23 @@ export function createTasksStore(
 
 	function shouldHandle(file: TFile): boolean {
 		const filenameFilter = getFilenameFilter()?.replace(/^\//, "");
-		return !filenameFilter || file.path.startsWith(filenameFilter);
+		if (filenameFilter && !file.path.startsWith(filenameFilter)) {
+			return false;
+		}
+
+		const settings = get(settingsStore);
+		const ignoreRegexString = settings.ignorePathsRegex ?? "";
+		if (ignoreRegexString.trim().length === 0) {
+			return true;
+		}
+
+		try {
+			const ignoreRegex = new RegExp(ignoreRegexString);
+			return !ignoreRegex.test(file.path);
+		} catch (_e) {
+			// If regex is invalid, ignore the setting
+			return true;
+		}
 	}
 
 	function initialise() {


### PR DESCRIPTION
Add an 'Ignore paths (regex)' setting to allow users to exclude files from the kanban based on their path.