### PR TITLE
feat: add sort by priority emoji

### DIFF
--- a/src/ui/components/column.svelte
+++ b/src/ui/components/column.svelte
@@ -35,6 +35,7 @@
 	export let columnColourTableStore: Readable<ColumnColourTable>;
 	export let showFilepath: boolean;
 	export let consolidateTags: boolean;
+	export let sortByPriority: boolean = false;
 	export let isVerticalFlow: boolean = false;
 	export let isCollapsed: boolean = false;
 	export let onToggleCollapse: () => void;
@@ -62,11 +63,14 @@
 	$: displayTaskCount = isCollapsed ? `${tasks.length}` : taskCountLabel;
 
 	$: sortedTasks = [...tasks].sort((a, b) => {
-		if (a.path === b.path) {
-			return a.rowIndex - b.rowIndex;
-		} else {
+		if (sortByPriority) {
+			const pd = a.priority - b.priority;
+			if (pd !== 0) return pd;
+		}
+		if (a.path !== b.path) {
 			return a.path.localeCompare(b.path);
 		}
+		return a.rowIndex - b.rowIndex;
 	});
 
 	// Selection state

--- a/src/ui/main.svelte
+++ b/src/ui/main.svelte
@@ -15,7 +15,7 @@
 	import type { TaskActions } from "./tasks/actions";
 	import { type SettingValues, VisibilityOption, FlowDirection } from "./settings/settings_store";
 	import { onMount } from "svelte";
-	import type { App } from "obsidian";
+	import { Menu, type App } from "obsidian";
 
 	export let app: App;
 	export let tasksStore: Writable<Task[]>;
@@ -415,6 +415,7 @@
 	$: ({
 		showFilepath = true,
 		consolidateTags = false,
+		sortByPriority = false,
 		uncategorizedVisibility = VisibilityOption.Auto,
 		doneVisibility = VisibilityOption.AlwaysShow,
 		filtersSidebarExpanded = true,
@@ -422,6 +423,19 @@
 		columnWidth = 300,
 		flowDirection = FlowDirection.LeftToRight
 	} = $settingsStore);
+
+	function showSortMenu(e: MouseEvent) {
+		const menu = new Menu();
+		menu.addItem((i) => {
+			i.setTitle("Emoji ranking")
+				.setChecked(sortByPriority)
+				.onClick(() => {
+					$settingsStore.sortByPriority = !sortByPriority;
+					requestSave();
+				});
+		});
+		menu.showAtMouseEvent(e);
+	}
 
 	$: showUncategorizedColumn =
 		uncategorizedVisibility === VisibilityOption.AlwaysShow ||
@@ -670,6 +684,7 @@
 						Total: {totalTaskCount} tasks
 					{/if}
 				</span>
+				<IconButton icon="lucide-arrow-up-down" on:click={showSortMenu} aria-label="Sort tasks" />
 				<IconButton icon="lucide-settings" on:click={handleOpenSettings} />
 			</div>
 			
@@ -686,6 +701,7 @@
 							{columnColourTableStore}
 							{showFilepath}
 							{consolidateTags}
+							{sortByPriority}
 							{isVerticalFlow}
 							isCollapsed={$collapsedColumnsStore.has(column)}
 							onToggleCollapse={() => toggleColumnCollapse(column)}

--- a/src/ui/settings/settings_store.ts
+++ b/src/ui/settings/settings_store.ts
@@ -84,6 +84,7 @@ const settingsObject = z.object({
 	columnWidth: z.number().min(200).max(600).default(300).optional(),
 	flowDirection: z.nativeEnum(FlowDirection).default(FlowDirection.LeftToRight).optional(),
 	collapsedColumns: z.array(z.string()).default([]).optional(),
+	sortByPriority: z.boolean().default(false).optional(),
 });
 
 export type SettingValues = z.infer<typeof settingsObject>;
@@ -105,6 +106,7 @@ export const defaultSettings: SettingValues = {
 	columnWidth: 300,
 	flowDirection: FlowDirection.LeftToRight,
 	collapsedColumns: [],
+	sortByPriority: false,
 };
 
 export const createSettingsStore = () =>

--- a/src/ui/tasks/task.ts
+++ b/src/ui/tasks/task.ts
@@ -76,6 +76,16 @@ export type CancelledStatusMarkers = Brand<string, "CancelledStatusMarkers">;
  */
 export const DEFAULT_CANCELLED_STATUS_MARKERS: CancelledStatusMarkers = "-" as CancelledStatusMarkers;
 
+export const PRIORITY_EMOJI_MAP = [
+	{ emoji: '\u{1F53A}', value: 1 }, // 🔺 highest
+	{ emoji: '\u{23EB}',  value: 2 }, // ⏫ high
+	{ emoji: '\u{1F53C}', value: 3 }, // 🔼 medium
+	{ emoji: '\u{1F53D}', value: 4 }, // 🔽 low
+	{ emoji: '\u{23EC}',  value: 5 }, // ⏬ lowest
+] as const;
+
+export const NO_PRIORITY_VALUE = 6;
+
 /**
  * Common validation logic for status marker strings.
  * 
@@ -389,6 +399,13 @@ export class Task {
 
 	readonly blockLink: string | undefined;
 	readonly tags: ReadonlySet<string>;
+
+	get priority(): number {
+		for (const { emoji, value } of PRIORITY_EMOJI_MAP) {
+			if (this.content.includes(emoji)) return value;
+		}
+		return NO_PRIORITY_VALUE;
+	}
 
 	serialise(): string {
 		if (this._deleted) {

--- a/src/ui/tasks/tests/task.tests.ts
+++ b/src/ui/tasks/tests/task.tests.ts
@@ -10,7 +10,9 @@ import {
 	createCancelledStatusMarkers,
 	validateIgnoredStatusMarkers,
 	createIgnoredStatusMarkers,
-	DEFAULT_CANCELLED_STATUS_MARKERS
+	DEFAULT_CANCELLED_STATUS_MARKERS,
+	PRIORITY_EMOJI_MAP,
+	NO_PRIORITY_VALUE,
 } from "../task";
 import { type ColumnTag, type ColumnTagTable } from "src/ui/columns/columns";
 import { kebab } from "src/parsing/kebab/kebab";
@@ -431,6 +433,72 @@ describe("Task", () => {
 				expect(task).toBeTruthy();
 				expect(task?.done).toBe(true);
 			});
+		});
+	});
+
+	describe("priority getter", () => {
+		it("returns 1 for highest priority emoji 🔺", () => {
+			const taskString = "- [ ] 🔺 Urgent task";
+			if (isTrackedTaskString(taskString)) {
+				const task = new Task(taskString, { path: "/" }, 0, columnTags, false, "xX", "-", "");
+				expect(task.priority).toBe(1);
+			}
+		});
+
+		it("returns 2 for high priority emoji ⏫", () => {
+			const taskString = "- [ ] ⏫ High priority task";
+			if (isTrackedTaskString(taskString)) {
+				const task = new Task(taskString, { path: "/" }, 0, columnTags, false, "xX", "-", "");
+				expect(task.priority).toBe(2);
+			}
+		});
+
+		it("returns 3 for medium priority emoji 🔼", () => {
+			const taskString = "- [ ] 🔼 Medium priority task";
+			if (isTrackedTaskString(taskString)) {
+				const task = new Task(taskString, { path: "/" }, 0, columnTags, false, "xX", "-", "");
+				expect(task.priority).toBe(3);
+			}
+		});
+
+		it("returns 4 for low priority emoji 🔽", () => {
+			const taskString = "- [ ] 🔽 Low priority task";
+			if (isTrackedTaskString(taskString)) {
+				const task = new Task(taskString, { path: "/" }, 0, columnTags, false, "xX", "-", "");
+				expect(task.priority).toBe(4);
+			}
+		});
+
+		it("returns 5 for lowest priority emoji ⏬", () => {
+			const taskString = "- [ ] ⏬ Lowest priority task";
+			if (isTrackedTaskString(taskString)) {
+				const task = new Task(taskString, { path: "/" }, 0, columnTags, false, "xX", "-", "");
+				expect(task.priority).toBe(5);
+			}
+		});
+
+		it("returns NO_PRIORITY_VALUE for tasks without priority emoji", () => {
+			const taskString = "- [ ] Regular task without priority";
+			if (isTrackedTaskString(taskString)) {
+				const task = new Task(taskString, { path: "/" }, 0, columnTags, false, "xX", "-", "");
+				expect(task.priority).toBe(NO_PRIORITY_VALUE);
+			}
+		});
+
+		it("returns first matching priority when multiple emojis present", () => {
+			const taskString = "- [ ] 🔺 Do this ⏬ later";
+			if (isTrackedTaskString(taskString)) {
+				const task = new Task(taskString, { path: "/" }, 0, columnTags, false, "xX", "-", "");
+				expect(task.priority).toBe(1);
+			}
+		});
+
+		it("returns NO_PRIORITY_VALUE for non-priority emojis", () => {
+			const taskString = "- [ ] 🚀 Ship it";
+			if (isTrackedTaskString(taskString)) {
+				const task = new Task(taskString, { path: "/" }, 0, columnTags, false, "xX", "-", "");
+				expect(task.priority).toBe(NO_PRIORITY_VALUE);
+			}
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Adds a sort button (↕) to the board toolbar that opens a dropdown with an "Emoji ranking" sort option
- When enabled, tasks within each column sort by priority emoji (🔺⏫🔼🔽⏬) before the default file path + line number ordering
- Tasks without a priority emoji sort last
- Sort preference persists across sessions

## Test plan
- [x] All 186 tests pass (`npm test`), including 8 new tests for the priority getter
- [x] Build passes (`npm run build`)
- [x] Manual: toggle sort on/off from toolbar button, verify tasks reorder by priority
- [x] Manual: verify sort state persists after closing and reopening the board

Created in collaboration with [Claude Code](https://claude.ai/claude-code)