### PR TITLE
docs: require explicit test verification before spec checkoff

### DIFF
--- a/README.planning.md
+++ b/README.planning.md
@@ -56,6 +56,9 @@
 
 **Tracking Guidelines:**
 - Mark tasks with ✅ as they're completed
+- Only check off test cases after they have been explicitly verified by the stated test method (for example by running the relevant automated test, or by performing the manual validation steps and confirming the result)
+- Do not check off a test case based only on implementation progress, code inspection, or expectation that it should pass
+- If a behavior appears implemented but has not yet been exercised, leave the test case unchecked until verification happens
 - Add phase status after title: `✅ COMPLETE`, `🚧 IN PROGRESS`, or leave blank if not started
 - Link to commits using short hash: `[99a67b6](full-commit-url)`
 - Link to PRs using number: `[#51](full-pr-url)`


### PR DESCRIPTION
## Summary
- clarify that spec test cases should only be checked off after explicit verification
- state that implementation progress or code inspection alone is not enough to mark a test case complete
- require unverified behaviors to remain unchecked until exercised

Created in collaboration with [Amp](https://ampcode.com)