### PR TITLE
test: update manual test vault fixtures

### DIFF
--- a/obsidian-plugin-dev/.obsidian/workspace.json
+++ b/obsidian-plugin-dev/.obsidian/workspace.json
@@ -53,9 +53,23 @@
                   "icon": "lucide-file",
                   "title": "2025-10-21"
                 }
+              },
+              {
+                "id": "077a4aa9b7f85c69",
+                "type": "leaf",
+                "state": {
+                  "type": "markdown",
+                  "state": {
+                    "file": "periodic/2025-05-01.md",
+                    "mode": "source",
+                    "source": false
+                  },
+                  "icon": "lucide-file",
+                  "title": "2025-05-01"
+                }
               }
             ],
-            "currentTab": 1
+            "currentTab": 3
           },
           {
             "id": "b672f997538ed1c3",
@@ -239,9 +253,10 @@
   },
   "active": "08d2136051d11382",
   "lastOpenFiles": [
-    "tasks/Even more tasks.md",
+    "periodic/2025-05-01.md",
     "periodic/Kanban-1761679356942.md",
     "periodic/2025-10-21.md",
+    "tasks/Even more tasks.md",
     "periodic/Kanban-1771182407942.md",
     "periodic/A test file with a very very very long name.md",
     "periodic/Kanban-repro.md",
@@ -250,7 +265,6 @@
     "periodic/@",
     "periodic/tasks.md",
     "periodic/Kanban-1774741379127.md",
-    "periodic/2025-05-01.md",
     "periodic/2025-10-27.md",
     "Untitled Kanban.md",
     "periodic/2025-05-02.md",

--- a/obsidian-plugin-dev/periodic/2025-05-01.md
+++ b/obsidian-plugin-dev/periodic/2025-05-01.md
@@ -1,16 +1,16 @@
-- [ ] Test #p-l-c-重要 #Next week #Next week #soon
+- [ ] Test #p-l-c-重要 #Next week #Next week #soonish
 - [ ] Test #gtd #To-do
-- [ ] Test #me #test #this-is-a-very-very-very-very-very-long-column-name
-- [/] Test a thing #travel #next-week
+- [ ] Test #me #test #this-is-a-very-very-very-very-long-column-name
+- [ ] Test a thing #travel #next-week
 - [ ] Test a thing #travel #next-week
 - [ ] Test a thing #travel #next-week
 - [f] Test #learning
 - [-] Test is the best #next-week
-- [ ] Test #soon
+- [ ] Test #soonish
 - [p] Testkk
 - [A] Test ✅ 2025-05-02
 - [ ] Test ✅ 2025-05-02 #To-do
 - [ ] Test ✅ 2025-05-02 #Pending
 - [T] Test
 - [ ] Test #To-do
-- [ ] TODO #soon
+- [ ] TODO #soonish

--- a/obsidian-plugin-dev/periodic/2025-05-02.md
+++ b/obsidian-plugin-dev/periodic/2025-05-02.md
@@ -13,7 +13,7 @@
 ## Today
 - [ ] [[Brain Dump]] #Next week
 - [ ] [[2025-10-27]] #this-week
-- [ ] #whatevs #soon
+- [ ] #whatevs #soonish
 
 ## Scheduled 
 ```tasks
@@ -55,6 +55,6 @@ short mode
 ```
 
 
-- [ ]  #this-is-a-very-very-very-very-very-long-column-name
+- [ ]  #this-is-a-very-very-very-very-long-column-name
 - [x] Foo bar
-- [ ] TODO #soon
+- [ ] TODO #soonish

--- a/obsidian-plugin-dev/periodic/2025-10-21.md
+++ b/obsidian-plugin-dev/periodic/2025-10-21.md
@@ -6,10 +6,11 @@
 	- [ ] Dave  #PL/C-重要 #To-do #01-later
 	- [ ] Eve #super-cool
 	- [ ] Frank #nested/tag #this-week
-	- [ ] Grace
+	- [ ] Grace in 2025-10-21 #archivedjj
 	- [ ] Later cat test #01-later #cat
 	- [ ] Overlapping columns test  #B #C #A
 	- [ ] Overlapping columns test  AB #B #A
+	- [ ] Test dragging #AnotherTag #next-week
 
 ## Top 1 next
 
@@ -50,5 +51,5 @@ short mode
 ```
 
 
-- [ ] TODO #this-is-a-very-very-very-very-very-long-column-name
+- [ ] TODO #this-is-a-very-very-very-very-long-column-name
 - [-] Let's make this a very very long task so we can get it to wrap. Gotta make sure that renders well #next-week

--- a/obsidian-plugin-dev/periodic/2025-10-27.md
+++ b/obsidian-plugin-dev/periodic/2025-10-27.md
@@ -3,10 +3,10 @@
 	- [ ] Alice 
 	- [ ] Bob 
 	- [ ] Carol #01-later
-	- [ ] Dave #this-is-a-very-very-very-very-very-long-column-name
+	- [ ] Dave #this-is-a-very-very-very-very-long-column-name
 	- [x] Eve
 	- [ ] Frank 
-	- [ ] Grace #soon
+	- [ ] Grace #soonish
 
 ## Top 1 next
 
@@ -46,4 +46,4 @@ short mode
 
 
 - [x] TODO
-- [ ] TODO #soon
+- [ ] TODO #soonish

--- a/obsidian-plugin-dev/periodic/Kanban-1761679356942.md
+++ b/obsidian-plugin-dev/periodic/Kanban-1761679356942.md
@@ -1,8 +1,26 @@
 ---
-kanban_plugin: '{"columns":[{"id":"column-later","label":"Later","matchMode":"tags","matchTags":["01-later"]},{"id":"column-new-column","label":"Later Cat","matchMode":"tags","matchTags":["cat","01-later"]},{"id":"column-new-column-3","label":"BC","matchMode":"tags","matchTags":["B","C"]},{"id":"column-new-column-2","label":"AB","matchMode":"tags","matchTags":["A","B"]},{"id":"column-soonish","label":"Soon","color":"#FF7F50","matchMode":"name","matchTags":[]},{"id":"column-this-is-a-very-very-very-very-very-long-column-name","label":"This is a very very very very very long column name","color":"#12e2ff","matchMode":"name","matchTags":[]},{"id":"column-next-week","label":"Next week","matchMode":"name","matchTags":[]},{"id":"column-this-week","label":"This week","matchMode":"name","matchTags":[]},{"id":"column-today","label":"Today","matchMode":"name","matchTags":[]},{"id":"column-in-progress","label":"In Progress","matchMode":"name","matchTags":[]},{"id":"column-pending","label":"Pending","matchMode":"name","matchTags":[]},{"id":"column-unused","label":"Unused","matchMode":"name","matchTags":[]},{"id":"column-review","label":"Review","matchMode":"name","matchTags":[]}],"scope":"selectedFolders","showFilepath":true,"consolidateTags":false,"uncategorizedVisibility":"always","doneVisibility":"auto","doneStatusMarkers":"xXc","cancelledStatusMarkers":"-b","ignoredStatusMarkers":"a","savedFilters":[{"id":"387634cb-e0a5-4832-a816-dfb68b0d65b8","content":{"text":"foo"}},{"id":"e9a83493-774e-452c-84f8-46a9f62d178f","tag":{"tags":["gtd"]}},{"id":"4c719301-3cf4-4659-ba02-ecf3735bd640","file":{"filepaths":["periodic/2025-05-01.md"]}},{"id":"010f43d1-ea3b-422c-ad8f-17a59fcac96d","tag":{"tags":["me"]}}],"lastContentFilter":"","lastTagFilter":[],"lastFileFilter":[],"columnWidth":300,"flowDirection":"ltr","collapsedColumns":["column-today","column-pending","uncategorised","column-this-is-a-very-very-very-very-very-long-column-name","column-unused"],"defaultTaskFile":"","lastUsedTaskFile":"tasks/Even more tasks.md","scopeFolders":["periodic","tasks"],"excludePaths":["periodic/subfolder"],"uncategorizedColumnName":"","doneColumnName":"Voila","filtersSidebarExpanded":true}'
+kanban_plugin: '{"columns":[{"id":"column-later","label":"Later","matchMode":"tags","matchTags":["01-later"]},{"id":"column-new-column","label":"Later Cat","matchMode":"tags","matchTags":["cat","01-later"]},{"id":"column-new-column-3","label":"BC","matchMode":"tags","matchTags":["B","C"]},{"id":"column-new-column-2","label":"AB","matchMode":"tags","matchTags":["A","B"]},{"id":"column-this-is-a-very-very-very-very-very-long-column-name","label":"This is a very very very very long column name","color":"#2cbbce","matchMode":"name","matchTags":[]},{"id":"column-soonish","label":"Soonish","color":"#FF7F50","matchMode":"name","matchTags":[]},{"id":"column-next-week","label":"Next week","matchMode":"name","matchTags":[]},{"id":"column-this-week","label":"This week","matchMode":"name","matchTags":[]},{"id":"column-today","label":"Today","matchMode":"name","matchTags":[]},{"id":"column-in-progress","label":"In Progress","matchMode":"name","matchTags":[]},{"id":"column-pending","label":"Pending","matchMode":"name","matchTags":[]},{"id":"column-unused","label":"Unused","matchMode":"name","matchTags":[]},{"id":"column-review","label":"Review","matchMode":"name","matchTags":[]}],"scope":"selectedFolders","showFilepath":true,"consolidateTags":false,"uncategorizedVisibility":"always","doneVisibility":"auto","doneStatusMarkers":"xXc","cancelledStatusMarkers":"-b","ignoredStatusMarkers":"a","savedFilters":[{"id":"387634cb-e0a5-4832-a816-dfb68b0d65b8","content":{"text":"foo"}},{"id":"e9a83493-774e-452c-84f8-46a9f62d178f","tag":{"tags":["gtd"]}},{"id":"4c719301-3cf4-4659-ba02-ecf3735bd640","file":{"filepaths":["periodic/2025-05-01.md"]}},{"id":"010f43d1-ea3b-422c-ad8f-17a59fcac96d","tag":{"tags":["me"]}}],"lastContentFilter":"","lastTagFilter":[],"lastFileFilter":[],"columnWidth":300,"flowDirection":"ltr","collapsedColumns":["column-today","column-pending","column-this-is-a-very-very-very-very-very-long-column-name","column-unused","column-next-week"],"defaultTaskFile":"","lastUsedTaskFile":"tasks/Even more tasks.md","scopeFolders":["periodic","tasks"],"excludePaths":["periodic/subfolder"],"uncategorizedColumnName":"","doneColumnName":"Voila","filtersSidebarExpanded":true}'
 ---
 - [ ] Does it work to put a task in the kanban file itself? #today
 - [ ] Woah! Two of them! #in-progress
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/obsidian-plugin-dev/tasks/Even more tasks.md
+++ b/obsidian-plugin-dev/tasks/Even more tasks.md
@@ -1,12 +1,12 @@
 - [ ] Foo bar baz qux la la la #in-progress 
 - [x] Testing is fun
 - [ ] This is how we do it #next-week
-- [ ] asdf #soon
+- [ ] asdf #soonish
 - [ ] [[Tasks]] #this-week
 - [ ] Slash name column #review
 - [ ] Another one #review #UnrelatedTag
 - [x] Let's test marking as done
 - [x] Let's test marking as done from a tag column
 - [ ] Lalala #01-later #UnrelatedTag
-- [ ] Dadada #UnrelatedTag #soon
+- [ ] Dadada #UnrelatedTag #soonish
 - [x] To be archived #archived


### PR DESCRIPTION
## Summary
- update the Obsidian manual-test vault files after column tag mapping verification
- refresh the sample kanban board state and related task fixtures
- keep the test-vault changes separate from the shipped source changes

## Testing
- manual test vault refresh only

Created in collaboration with [Amp](https://ampcode.com)