### PR TITLE
fix(deps): bump vitest to 4.x (resolves CVE-2026-47429)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,13 +27,13 @@
 				"builtin-modules": "4.0.0",
 				"esbuild": "^0.27.7",
 				"esbuild-svelte": "^0.8.1",
-				"obsidian": "*",
+				"obsidian": "latest",
 				"svelte": "^5.56.0",
 				"svelte-preprocess": "^5.1.4",
 				"tslib": "2.6.2",
 				"typescript": "5.4.5",
 				"vite": "^7.3.2",
-				"vitest": "^3.2.4"
+				"vitest": "^4.1.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -692,9 +692,9 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-			"integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1487,6 +1487,13 @@
 				"@smui/ripple": "^8.0.3"
 			}
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@sveltejs/acorn-typescript": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
@@ -1504,13 +1511,14 @@
 			"dev": true
 		},
 		"node_modules/@types/chai": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-			"integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/deep-eql": "*"
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
 			}
 		},
 		"node_modules/@types/codemirror": {
@@ -1767,59 +1775,87 @@
 			"peer": true
 		},
 		"node_modules/@vitest/expect": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-			"integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+			"integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "3.2.4",
-				"@vitest/utils": "3.2.4",
-				"chai": "^5.2.0",
-				"tinyrainbow": "^2.0.0"
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
-		"node_modules/@vitest/pretty-format": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-			"integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+			"integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tinyrainbow": "^2.0.0"
+				"@vitest/spy": "4.1.8",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+			"integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-			"integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+			"integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "3.2.4",
-				"pathe": "^2.0.3",
-				"strip-literal": "^3.0.0"
+				"@vitest/utils": "4.1.8",
+				"pathe": "^2.0.3"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-			"integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+			"integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "3.2.4",
-				"magic-string": "^0.30.17",
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -1827,28 +1863,25 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-			"integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+			"integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"tinyspy": "^4.0.3"
-			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-			"integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+			"integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "3.2.4",
-				"loupe": "^3.1.4",
-				"tinyrainbow": "^2.0.0"
+				"@vitest/pretty-format": "4.1.8",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
@@ -2042,16 +2075,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/cac": {
-			"version": "6.7.14",
-			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2063,18 +2086,11 @@
 			}
 		},
 		"node_modules/chai": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
-			"integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"assertion-error": "^2.0.1",
-				"check-error": "^2.1.1",
-				"deep-eql": "^5.0.1",
-				"loupe": "^3.1.0",
-				"pathval": "^2.0.0"
-			},
 			"engines": {
 				"node": ">=18"
 			}
@@ -2094,16 +2110,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/check-error": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-			"integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16"
 			}
 		},
 		"node_modules/chokidar": {
@@ -2176,6 +2182,13 @@
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
 		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2213,16 +2226,6 @@
 				"supports-color": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/deep-eql": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/deep-is": {
@@ -2274,9 +2277,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2560,6 +2563,7 @@
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
 			}
@@ -2575,9 +2579,9 @@
 			}
 		},
 		"node_modules/expect-type": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
-			"integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -3075,13 +3079,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/js-tokens": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/js-yaml": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3178,21 +3175,14 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/loupe": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.0.tgz",
-			"integrity": "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/magic-string": {
-			"version": "0.30.17",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-			"integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.0"
+				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"node_modules/merge2": {
@@ -3327,6 +3317,20 @@
 				"@codemirror/view": "^6.0.0"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+			"integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3448,16 +3452,6 @@
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/pathval": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-			"integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14.16"
-			}
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -4205,9 +4199,9 @@
 			"dev": true
 		},
 		"node_modules/std-env": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
-			"integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4255,19 +4249,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/strip-literal": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
-			"integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"js-tokens": "^9.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/style-mod": {
@@ -4441,11 +4422,14 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.16",
@@ -4495,30 +4479,10 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/tinypool": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-			"integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.0.0 || >=20.0.0"
-			}
-		},
 		"node_modules/tinyrainbow": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/tinyspy": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
-			"integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4690,29 +4654,6 @@
 				}
 			}
 		},
-		"node_modules/vite-node": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-			"integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cac": "^6.7.14",
-				"debug": "^4.4.1",
-				"es-module-lexer": "^1.7.0",
-				"pathe": "^2.0.3",
-				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-			},
-			"bin": {
-				"vite-node": "vite-node.mjs"
-			},
-			"engines": {
-				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
 		"node_modules/vite/node_modules/fdir": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4745,65 +4686,79 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+			"integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/chai": "^5.2.2",
-				"@vitest/expect": "3.2.4",
-				"@vitest/mocker": "3.2.4",
-				"@vitest/pretty-format": "^3.2.4",
-				"@vitest/runner": "3.2.4",
-				"@vitest/snapshot": "3.2.4",
-				"@vitest/spy": "3.2.4",
-				"@vitest/utils": "3.2.4",
-				"chai": "^5.2.0",
-				"debug": "^4.4.1",
-				"expect-type": "^1.2.1",
-				"magic-string": "^0.30.17",
+				"@vitest/expect": "4.1.8",
+				"@vitest/mocker": "4.1.8",
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/runner": "4.1.8",
+				"@vitest/snapshot": "4.1.8",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
 				"pathe": "^2.0.3",
-				"picomatch": "^4.0.2",
-				"std-env": "^3.9.0",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
 				"tinybench": "^2.9.0",
-				"tinyexec": "^0.3.2",
-				"tinyglobby": "^0.2.14",
-				"tinypool": "^1.1.1",
-				"tinyrainbow": "^2.0.0",
-				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-				"vite-node": "3.2.4",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
 				"vitest": "vitest.mjs"
 			},
 			"engines": {
-				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
-				"@types/debug": "^4.1.12",
-				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-				"@vitest/browser": "3.2.4",
-				"@vitest/ui": "3.2.4",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.8",
+				"@vitest/browser-preview": "4.1.8",
+				"@vitest/browser-webdriverio": "4.1.8",
+				"@vitest/coverage-istanbul": "4.1.8",
+				"@vitest/coverage-v8": "4.1.8",
+				"@vitest/ui": "4.1.8",
 				"happy-dom": "*",
-				"jsdom": "*"
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@edge-runtime/vm": {
 					"optional": true
 				},
-				"@types/debug": {
+				"@opentelemetry/api": {
 					"optional": true
 				},
 				"@types/node": {
 					"optional": true
 				},
-				"@vitest/browser": {
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
 					"optional": true
 				},
 				"@vitest/ui": {
@@ -4814,33 +4769,9 @@
 				},
 				"jsdom": {
 					"optional": true
-				}
-			}
-		},
-		"node_modules/vitest/node_modules/@vitest/mocker": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-			"integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/spy": "3.2.4",
-				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.17"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"msw": "^2.4.9",
-				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-			},
-			"peerDependenciesMeta": {
-				"msw": {
-					"optional": true
 				},
 				"vite": {
-					"optional": true
+					"optional": false
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"tslib": "2.6.2",
 		"typescript": "5.4.5",
 		"vite": "^7.3.2",
-		"vitest": "^3.2.4"
+		"vitest": "^4.1.0"
 	},
 	"overrides": {
 		"flatted": ">=3.4.2"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
 
 export default defineConfig({
+	resolve: {
+		alias: {
+			// Tests import modules as `src/...` (resolved via tsconfig baseUrl).
+			// Vitest 4 no longer applies tsconfig `baseUrl` automatically, so map
+			// the `src` root explicitly.
+			src: fileURLToPath(new URL("./src", import.meta.url)),
+		},
+	},
 	test: {
 		include: ["**/*.tests.ts"],
 		exclude: ["**/node_modules/**", "**/dist/**", "**/build/**", "**/worktrees/**"],


### PR DESCRIPTION
Resolves Dependabot alert [#60](https://github.com/ErikaRS/task-list-kanban/security/dependabot/60).

## What
- Bump `vitest` `^3.2.4` → `^4.1.0` (installed 4.1.8).
- Add `resolve.alias` (`src` → `./src`) to `vite.config.ts`.

## Why
**GHSA-5xrq-8626-4rwp / CVE-2026-47429** (critical, CVSS 9.8): when the Vitest UI server is listening — especially exposed to the network — arbitrary files can be read and scripts executed. Fixed in vitest 4.1.0.

Real-world exposure here was minimal (dev-only dependency; the project runs headless `vitest run` with no UI server), but the bump clears the critical alert.

## Test config note
Vitest 4 dropped the implicit tsconfig `baseUrl` resolution that the tests relied on to import `src/...` specifiers. The added alias restores that resolution explicitly.

## Verification
- `npm test` → 16 files, 339 tests passing.
- `npm ls vitest` → `4.1.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)