### PR TITLE
Add a phone-friendly stacked board layout

### DIFF
--- a/src/ui/board/board_mobile_list.svelte
+++ b/src/ui/board/board_mobile_list.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+	import type { App, TFile } from "obsidian";
+	import type { Readable } from "svelte/store";
+	import { getBoardCell, type BoardMatrix, type PrimaryBucketId } from "./board_matrix";
+	import type {
+		ColumnTagTable,
+		ColumnColourTable,
+		ColumnMatchTagTable,
+		ColumnSubtitleTable,
+	} from "../columns/columns";
+	import type { TaskActions } from "../tasks/actions";
+	import ColumnHeader from "../components/ColumnHeader.svelte";
+	import BoardCell from "./BoardCell.svelte";
+	import { PropertyDisplayMode } from "../settings/settings_store";
+	import { PropertySchemaOption } from "../../parsing/properties/property_schema";
+	import type { ManualOrderStore } from "../tasks/manual_order";
+
+	export let app: App;
+	export let matrix: BoardMatrix;
+	export let taskActions: TaskActions;
+	export let columnTagTableStore: Readable<ColumnTagTable>;
+	export let columnColourTableStore: Readable<ColumnColourTable>;
+	export let columnMatchTagTableStore: Readable<ColumnMatchTagTable>;
+	export let columnSubtitleTableStore: Readable<ColumnSubtitleTable>;
+	export let showFilepath: boolean;
+	export let propertyDisplay: PropertyDisplayMode = PropertyDisplayMode.None;
+	export let propertySchemaOption: PropertySchemaOption = PropertySchemaOption.None;
+	export let consolidateTags: boolean;
+	export let excludedTags: string[] = [];
+	export let targetTaskFile: TFile | null = null;
+	export let targetFileIsDefault = false;
+	export let onToggleCollapse: (columnId: PrimaryBucketId) => void;
+	export let uncategorizedColumnName: string | undefined = undefined;
+	export let doneColumnName: string | undefined = undefined;
+	export let isManualOrder = false;
+	export let manualOrder: ManualOrderStore = {};
+	export let reorderEnabled = false;
+	export let treatNestedTasksAsSubtasks = false;
+
+	$: tasksByPrimary = Object.fromEntries(
+		matrix.primaryAxis.map((bucket) => [
+			bucket.id,
+			Object.values(matrix.cells[bucket.id] || {}).flatMap((cell) => cell.tasks),
+		]),
+	);
+
+	$: showGroupLabels =
+		matrix.secondaryAxis.length > 1 ||
+		(matrix.secondaryAxis.length > 0 && !matrix.secondaryAxis[0]?.meta?.isDefault);
+</script>
+
+<div class="mobile-board-list">
+	{#each matrix.primaryAxis as pBucket (pBucket.id)}
+		<section class="mobile-column" style:--column-color={pBucket.meta?.color}>
+			<header class="mobile-column-header">
+				<ColumnHeader
+					column={pBucket.id}
+					tasks={tasksByPrimary[pBucket.id] ?? []}
+					{taskActions}
+					{columnTagTableStore}
+					{columnColourTableStore}
+					{columnMatchTagTableStore}
+					{columnSubtitleTableStore}
+					isVerticalFlow={true}
+					isCollapsed={pBucket.collapsed}
+					onToggleCollapse={() => onToggleCollapse(pBucket.id)}
+					{uncategorizedColumnName}
+					{doneColumnName}
+				/>
+			</header>
+
+			{#if !pBucket.collapsed}
+				{#each matrix.secondaryAxis as sBucket (sBucket.id)}
+					<div class="mobile-cell">
+						{#if showGroupLabels}
+							<h3 class="mobile-group-label">{sBucket.label}</h3>
+						{/if}
+						<BoardCell
+							{app}
+							cell={getBoardCell(matrix, pBucket.id, sBucket.id)}
+							primaryTasks={tasksByPrimary[pBucket.id] ?? []}
+							secondaryAxisBucket={sBucket}
+							primaryAxisLabel={pBucket.label}
+							{taskActions}
+							{columnTagTableStore}
+							{showFilepath}
+							{propertyDisplay}
+							{propertySchemaOption}
+							{consolidateTags}
+							{excludedTags}
+							{treatNestedTasksAsSubtasks}
+							isVerticalFlow={false}
+							{targetTaskFile}
+							{targetFileIsDefault}
+							{doneColumnName}
+							accentColor={pBucket.meta?.color}
+							{isManualOrder}
+							manualOrderEntries={manualOrder[sBucket.id]?.[pBucket.id]}
+							{reorderEnabled}
+						/>
+					</div>
+				{/each}
+			{/if}
+		</section>
+	{/each}
+</div>
+
+<style lang="scss">
+	.mobile-board-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-4-3);
+		width: 100%;
+		padding-bottom: var(--size-4-4);
+	}
+
+	.mobile-column {
+		min-width: 0;
+		overflow: hidden;
+		border: var(--border-width) solid var(--background-modifier-border);
+		border-radius: var(--radius-m);
+		background: var(--background-primary);
+		box-shadow: var(--shadow-s);
+	}
+
+	.mobile-column-header {
+		position: sticky;
+		top: 0;
+		z-index: 4;
+		padding: var(--size-4-2) var(--size-4-3);
+		background: color-mix(in srgb, var(--background-secondary) 72%, var(--background-primary));
+		border-bottom: var(--border-width) solid var(--background-modifier-border);
+	}
+
+	.mobile-cell {
+		min-width: 0;
+		padding: var(--size-4-3);
+		background: color-mix(in srgb, var(--background-primary) 88%, var(--background-secondary));
+
+		& + & {
+			border-top: var(--border-width) solid var(--background-modifier-border);
+		}
+	}
+
+	.mobile-group-label {
+		margin: 0 0 var(--size-4-2);
+		color: var(--text-muted);
+		font-size: var(--font-ui-small);
+	}
+</style>
+

--- a/src/ui/components/task.svelte
+++ b/src/ui/components/task.svelte
@@ -10,7 +10,7 @@
 	import TaskMenu from "./task_menu.svelte";
 	import TaskDateFields from "./TaskDateFields.svelte";
 	import Icon from "./icon.svelte";
-	import { Component, Keymap, MarkdownRenderer, type App } from "obsidian";
+	import { Component, Keymap, MarkdownRenderer, Platform, type App } from "obsidian";
 	import type { Readable } from "svelte/store";
 	import { onDestroy } from "svelte";
 	import { PropertyDisplayMode } from "../settings/settings_store";
@@ -18,6 +18,7 @@
 	import { EDITABLE_DATE_PROPERTY_KEYS, getPropertyWriteAdapter } from "../../parsing/properties/write";
 	import { toDisplayProperties, stripDisplayedPropertiesFromContent } from "../../parsing/properties/display";
 	import { renderTaskMarkdownSource } from "./task_markdown";
+	import { lockMobileBoardLayout } from "../mobile_editor_layout";
 
 	export let app: App;
 	export let task: Task;
@@ -45,6 +46,7 @@
 	export let treatNestedTasksAsSubtasks: boolean = false;
 
 	function handleContentBlur() {
+		stopWatchingEditViewport();
 		isEditing = false;
 
 		const content = textAreaEl?.value;
@@ -129,6 +131,73 @@
 	let previewContainerEl: HTMLDivElement | undefined;
 	let markdownComponent: Component | undefined;
 	let isEditingDates = false;
+	let stopWatchingEditViewport: () => void = () => {};
+	let unlockBoardLayout: () => void = () => {};
+	let mobileEditStyle = "";
+
+	function mobileEditPortal(node: HTMLTextAreaElement) {
+		if (!Platform.isMobile && !window.matchMedia("(max-width: 760px)").matches) {
+			return {};
+		}
+
+		document.body.appendChild(node);
+		return {
+			destroy() {
+				node.remove();
+			},
+		};
+	}
+
+	function positionMobileTaskEditor() {
+		requestAnimationFrame(() => {
+			if (!textAreaEl || (!Platform.isMobile && !window.matchMedia("(max-width: 760px)").matches)) {
+				mobileEditStyle = "";
+				return;
+			}
+
+			const viewport = window.visualViewport;
+			const viewportWidth = viewport?.width ?? window.innerWidth;
+			const viewportHeight = viewport?.height ?? window.innerHeight;
+			const viewportLeft = viewport?.offsetLeft ?? 0;
+			const viewportTop = viewport?.offsetTop ?? 0;
+			const margin = 16;
+			const editorWidth = Math.min(520, Math.max(200, viewportWidth - margin * 2));
+			const editorMaxHeight = Math.max(96, viewportHeight - margin * 2);
+			const editorHeight = Math.min(
+				Math.max(112, textAreaEl.scrollHeight),
+				editorMaxHeight,
+			);
+			const top = viewportTop + Math.max(margin, (viewportHeight - editorHeight) / 2);
+			mobileEditStyle = [
+				`left: ${Math.round(viewportLeft + (viewportWidth - editorWidth) / 2)}px`,
+				`top: ${Math.round(top)}px`,
+				`width: ${Math.round(editorWidth)}px`,
+				`height: ${Math.round(editorHeight)}px`,
+				`max-height: ${Math.round(editorMaxHeight)}px`,
+			].join("; ");
+		});
+	}
+
+	function watchEditViewport() {
+		stopWatchingEditViewport();
+		unlockBoardLayout();
+		unlockBoardLayout = lockMobileBoardLayout();
+		const viewport = window.visualViewport;
+		if (viewport) {
+			viewport.addEventListener("resize", positionMobileTaskEditor);
+			viewport.addEventListener("scroll", positionMobileTaskEditor);
+		}
+		stopWatchingEditViewport = () => {
+			if (viewport) {
+				viewport.removeEventListener("resize", positionMobileTaskEditor);
+				viewport.removeEventListener("scroll", positionMobileTaskEditor);
+			}
+			stopWatchingEditViewport = () => {};
+			unlockBoardLayout();
+			unlockBoardLayout = () => {};
+		};
+		positionMobileTaskEditor();
+	}
 	const editableDatePropertyKeys = new Set<string>(EDITABLE_DATE_PROPERTY_KEYS);
 
 	const interactiveTagNames = new Set([
@@ -372,6 +441,8 @@
 
 	// Cleanup on destroy
 	onDestroy(() => {
+		stopWatchingEditViewport();
+		unlockBoardLayout();
 		if (markdownComponent) {
 			markdownComponent.unload();
 		}
@@ -387,6 +458,7 @@
 	function onInput(e: Event & { currentTarget: HTMLTextAreaElement }) {
 		e.currentTarget.style.height = `0px`;
 		e.currentTarget.style.height = `${e.currentTarget.scrollHeight}px`;
+		positionMobileTaskEditor();
 	}
 
 	$: excludedTagNames = excludedTags.map((tag) => tag.trim().replace(/^#/, "").toLowerCase());
@@ -475,9 +547,13 @@
 			{#if isEditing}
 				<textarea
 					class:editing={isEditing}
+					class:mobile-task-editor={Platform.isMobile}
 					bind:this={textAreaEl}
+					use:mobileEditPortal
+					style={mobileEditStyle}
 					on:keypress={handleKeypress}
 					on:blur={handleContentBlur}
+					on:focus={watchEditViewport}
 					on:input={onInput}
 					value={task.content.replaceAll("<br />", "\n")}
 				></textarea>
@@ -656,6 +732,39 @@
 </div>
 
 <style lang="scss">
+	@mixin mobile-editor-surface {
+		position: fixed;
+		z-index: 1000;
+		box-sizing: border-box;
+		margin: 0;
+		padding: var(--size-4-3);
+		overflow: auto;
+		resize: none;
+		background: color-mix(in srgb, var(--background-primary) 94%, transparent);
+		color: var(--text-normal);
+		border: 1px solid color-mix(in srgb, var(--interactive-accent) 55%, var(--background-modifier-border));
+		border-radius: var(--radius-l, 12px);
+		box-shadow:
+			0 18px 48px rgba(0, 0, 0, 0.24),
+			0 0 0 3px color-mix(in srgb, var(--interactive-accent) 18%, transparent);
+		backdrop-filter: blur(14px) saturate(1.15);
+		-webkit-backdrop-filter: blur(14px) saturate(1.15);
+		font-size: 16px;
+		line-height: 1.45;
+		outline: none;
+	}
+
+	@media (max-width: 760px) {
+		textarea.mobile-task-editor,
+		textarea.editing {
+			@include mobile-editor-surface;
+		}
+	}
+
+	textarea.mobile-task-editor {
+		@include mobile-editor-surface;
+	}
+
 	.task {
 		--task-accent: var(--task-accent-color, var(--background-modifier-border-hover));
 		--task-content-line-height: 1.5rem;

--- a/src/ui/main.svelte
+++ b/src/ui/main.svelte
@@ -11,6 +11,7 @@
 	import type { Task } from "./tasks/task";
 	import BoardMatrixVertical from "./board/board_matrix_vertical.svelte";
 	import BoardMatrixHorizontal from "./board/board_matrix_horizontal.svelte";
+	import BoardMobileList from "./board/board_mobile_list.svelte";
 	import { deriveBoardMatrix } from "./board/board_matrix";
 	import ViewEditor from "./view_editor.svelte";
 	import {
@@ -74,7 +75,7 @@
 	import BoardRail from "./dashboard/board_rail.svelte";
 	import { shouldSwitchBoard } from "./dashboard/dashboard_panel_state";
 	import { railVisible as boardRailVisible, RAIL_MIN_WIDTH } from "./dashboard/board_rail_state";
-	import { Notice, TFile } from "obsidian";
+	import { Notice, Platform, TFile } from "obsidian";
 	import type { BoardListSettings, BoardRailSettings } from "./settings/global_settings";
 	import type { BoardTaskCounts } from "./dashboard/board_stats";
 	import {
@@ -124,11 +125,14 @@
 	// count includes hidden boards, so dashboard curation can't remove it.
 	$: railVisible = boardRailVisible($boardIndexStore.length);
 	$: railWidth = $boardRailSettingsStore?.width ?? RAIL_MIN_WIDTH;
+	let isMobileViewport = Platform.isMobile ||
+		(typeof window !== "undefined" && window.innerWidth <= 760);
 	// Dock side is a plugin setting (default left); top turns the content
 	// row into a column with the rail strip on top, and the dashboard
 	// slides down out of it instead of out from the left.
 	$: railDock = $boardRailSettingsStore?.dock ?? "left";
-	$: railOnTop = railVisible && railDock === "top";
+	$: effectiveRailDock = isMobileViewport ? "top" : railDock;
+	$: railOnTop = railVisible && effectiveRailDock === "top";
 	let railDashboardButtonEl: HTMLButtonElement | undefined;
 
 	// --- Board dashboard panel (SPEC 0033) ---
@@ -751,6 +755,7 @@
 	}
 
 	function handleWindowViewportChange() {
+		isMobileViewport = Platform.isMobile || window.innerWidth <= 760;
 		updateViewEditorPopoverPosition();
 	}
 
@@ -1013,7 +1018,7 @@
 				onToggleDashboard={toggleDashboard}
 				onSelect={handleDashboardSelect}
 				{onReorderBoards}
-				dock={railDock}
+				dock={effectiveRailDock}
 				width={railWidth}
 				onSetWidth={onSetRailWidth}
 				bind:dashboardButtonEl={railDashboardButtonEl}
@@ -1168,7 +1173,31 @@
 					class:vertical-flow={isVerticalFlow}
 					style="--column-width: {columnWidth}px;"
 				>
-					{#if !isVerticalFlow}
+					{#if isMobileViewport}
+						<BoardMobileList
+							{app}
+							matrix={activeMatrix}
+							{taskActions}
+							{columnTagTableStore}
+							{columnColourTableStore}
+							{columnMatchTagTableStore}
+							{columnSubtitleTableStore}
+							{showFilepath}
+							{consolidateTags}
+							excludedTags={$settingsStore.excludedTags ?? []}
+							{targetTaskFile}
+							{targetFileIsDefault}
+							onToggleCollapse={toggleColumnCollapse}
+							{uncategorizedColumnName}
+							{doneColumnName}
+							{propertyDisplay}
+							{propertySchemaOption}
+							{isManualOrder}
+							{manualOrder}
+							{reorderEnabled}
+							{treatNestedTasksAsSubtasks}
+						/>
+					{:else if !isVerticalFlow}
 						<BoardMatrixHorizontal
 							{app}
 							matrix={activeMatrix}

--- a/src/ui/mobile_editor_layout.ts
+++ b/src/ui/mobile_editor_layout.ts
@@ -1,0 +1,34 @@
+let lockedBoard: HTMLElement | null = null;
+let previousMinHeight = "";
+let lockCount = 0;
+
+/**
+ * Preserve the board's pre-keyboard height while a mobile editor is focused.
+ * Obsidian Mobile resizes its workspace when the soft keyboard opens; without
+ * an explicit floor, the flex board can collapse to zero height behind the
+ * editor.
+ */
+export function lockMobileBoardLayout(): () => void {
+	lockCount += 1;
+	if (lockCount === 1) {
+		lockedBoard = document.querySelector<HTMLElement>(
+			".task-list-kanban-view .board-main",
+		);
+		if (lockedBoard) {
+			previousMinHeight = lockedBoard.style.minHeight;
+			lockedBoard.style.minHeight = `${Math.ceil(lockedBoard.getBoundingClientRect().height)}px`;
+		}
+	}
+
+	let released = false;
+	return () => {
+		if (released) return;
+		released = true;
+		lockCount = Math.max(0, lockCount - 1);
+		if (lockCount === 0 && lockedBoard) {
+			lockedBoard.style.minHeight = previousMinHeight;
+			lockedBoard = null;
+			previousMinHeight = "";
+		}
+	};
+}


### PR DESCRIPTION
## What changed

On phones, the board is shown as a vertical list of collapsible columns instead of a wide horizontal grid. The board switcher moves to the top, and editing an existing task stays usable when the Android keyboard is open.

This is separate from #181 so the larger layout change can be reviewed on its own. The two PRs currently share one small mobile layout helper; I can rebase whichever one is reviewed second.

## Checks

- `npm run build`
- `npm test` (929 tests passed)
- tested in Obsidian Mobile on Android in portrait orientation

Refs #176

Assisted-by: Codex <codex@openai.com>